### PR TITLE
백준 1436번 문제

### DIFF
--- a/src/jooeun/baekjoon/P_1436.java
+++ b/src/jooeun/baekjoon/P_1436.java
@@ -1,0 +1,41 @@
+package jooeun.baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+public class P_1436 {
+
+    static int n;
+    static int answer=666;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+
+        if(n > 1){
+            dfs((int)Math.pow(10,3) + answer,1);
+        }
+
+        System.out.println(answer);
+    }
+
+    private static void dfs(int num,int k){
+
+        String temp = num + "";
+
+        if(temp.contains("666")){
+            k +=1 ;
+        }
+
+        if( k == n){
+            answer = num;
+            return;
+        }
+
+        dfs(num +1 ,k);
+
+    }
+}


### PR DESCRIPTION
문제 해결 : 해당 숫자를 string 으로 변환하여 "666"을 포함하고 있을 경우에는 k++하여 재귀함수 호출.
	    처음 시작 하는 숫자를 계산하여 넣어줌으로서, 재귀 함수 호출 횟주를 줄임
            string 클래스의 함수를 이요하다보니 메모리를 너무 많이 먹는 경향이 있음